### PR TITLE
Just return the data from plugin functions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,7 +12,7 @@ Description: Access databases from 'orderly2' while running reports.
 License: MIT + file LICENSE
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.2
+RoxygenNote: 7.2.3
 URL: https://github.com/vimc/orderly.db
 BugReports: https://github.com/vimc/orderly.db/issues
 Imports:

--- a/R/db.R
+++ b/R/db.R
@@ -29,8 +29,6 @@ orderly_db_view <- function(query, as, database = NULL, instance = NULL) {
 ##'
 ##' @param query Query to evaluate
 ##'
-##' @param as Name of the object to create
-##'
 ##' @param database The name of the database. This can be omitted (or
 ##'   `NULL`) where you only have a single database, but must be
 ##'   specified if you have more than one database configured.
@@ -39,19 +37,17 @@ orderly_db_view <- function(query, as, database = NULL, instance = NULL) {
 ##'   `database`). This can be omitted (or `NULL`) where you have not
 ##'   used instances or where you have only one configured.
 ##'
-##' @return Undefined
+##' @return The extracted data
 ##' @export
-orderly_db_query <- function(query, as, database = NULL, instance = NULL) {
-  assert_scalar_character(as)
+orderly_db_query <- function(query, database = NULL, instance = NULL) {
   ctx <- orderly2::orderly_plugin_context("orderly.db")
   con <- open_connection(ctx$path, ctx$config, ctx$envir, database, instance)
   query <- check_query(query, ctx)
   d <- DBI::dbGetQuery(con$connection, query)
-  ctx$envir[[as]] <- d
-  info <- list(database = con$database, as = as, query = query,
+  info <- list(database = con$database, query = query,
                rows = nrow(d), cols = names(d))
   orderly2::orderly_plugin_add_metadata("orderly.db", "query", info)
-  invisible()
+  d
 }
 
 
@@ -59,19 +55,16 @@ orderly_db_query <- function(query, as, database = NULL, instance = NULL) {
 ##'
 ##' @title Create connection to database
 ##'
-##' @param as Name of the object create
-##'
 ##' @inheritParams orderly_db_query
 ##'
-##' @return Undefined
+##' @return The connection object
 ##' @export
-orderly_db_connection <- function(as, database = NULL, instance = NULL) {
-  assert_scalar_character(as)
+orderly_db_connection <- function(database = NULL, instance = NULL) {
   ctx <- orderly2::orderly_plugin_context("orderly.db")
   con <- open_connection(ctx$path, ctx$config, ctx$envir, database, instance)
-  ctx$envir[[as]] <- con$connection
-  info <- list(database = con$database, as = as)
+  info <- list(database = con$database)
   orderly2::orderly_plugin_add_metadata("orderly.db", "connection", info)
+  con$connection
 }
 
 

--- a/R/db.R
+++ b/R/db.R
@@ -12,7 +12,7 @@
 ##' @export
 orderly_db_view <- function(query, as, database = NULL, instance = NULL) {
   assert_scalar_character(as)
-  ctx <- orderly2::orderly_plugin_context("orderly.db")
+  ctx <- orderly2::orderly_plugin_context("orderly.db", parent.frame())
   query <- check_query(query, ctx)
   con <- open_connection(ctx$path, ctx$config, ctx$envir, database, instance)
   sql <- sprintf("CREATE TEMPORARY VIEW %s AS\n%s", as, query)
@@ -40,7 +40,7 @@ orderly_db_view <- function(query, as, database = NULL, instance = NULL) {
 ##' @return The extracted data
 ##' @export
 orderly_db_query <- function(query, database = NULL, instance = NULL) {
-  ctx <- orderly2::orderly_plugin_context("orderly.db")
+  ctx <- orderly2::orderly_plugin_context("orderly.db", parent.frame())
   con <- open_connection(ctx$path, ctx$config, ctx$envir, database, instance)
   query <- check_query(query, ctx)
   d <- DBI::dbGetQuery(con$connection, query)
@@ -60,7 +60,7 @@ orderly_db_query <- function(query, database = NULL, instance = NULL) {
 ##' @return The connection object
 ##' @export
 orderly_db_connection <- function(database = NULL, instance = NULL) {
-  ctx <- orderly2::orderly_plugin_context("orderly.db")
+  ctx <- orderly2::orderly_plugin_context("orderly.db", parent.frame())
   con <- open_connection(ctx$path, ctx$config, ctx$envir, database, instance)
   info <- list(database = con$database)
   orderly2::orderly_plugin_add_metadata("orderly.db", "connection", info)

--- a/inst/orderly.db.json
+++ b/inst/orderly.db.json
@@ -13,9 +13,6 @@
                     "database": {
                         "type": "string"
                     },
-                    "as": {
-                        "type": "string"
-                    },
                     "query": {
                         "type": "string"
                     },
@@ -29,7 +26,7 @@
                         }
                     }
                 },
-                "required": ["database", "as", "query", "rows", "cols"]
+                "required": ["database", "query", "rows", "cols"]
                 "additionalProperties": false
             }
         },
@@ -59,12 +56,9 @@
                 "properties": {
                     "database": {
                         "type": "string"
-                    },
-                    "as": {
-                        "type": "string"
                     }
                 },
-                "required": ["database", "as"]
+                "required": ["database"]
                 "additionalProperties": false
             }
         }

--- a/man/orderly_db_connection.Rd
+++ b/man/orderly_db_connection.Rd
@@ -7,8 +7,6 @@
 orderly_db_connection(as, database = NULL, instance = NULL)
 }
 \arguments{
-\item{as}{Name of the object create}
-
 \item{database}{The name of the database. This can be omitted (or
 \code{NULL}) where you only have a single database, but must be
 specified if you have more than one database configured.}
@@ -18,7 +16,7 @@ specified if you have more than one database configured.}
 used instances or where you have only one configured.}
 }
 \value{
-Undefined
+The connection object
 }
 \description{
 Create a persistent connection object to the database

--- a/man/orderly_db_connection.Rd
+++ b/man/orderly_db_connection.Rd
@@ -4,7 +4,7 @@
 \alias{orderly_db_connection}
 \title{Create connection to database}
 \usage{
-orderly_db_connection(as, database = NULL, instance = NULL)
+orderly_db_connection(database = NULL, instance = NULL)
 }
 \arguments{
 \item{database}{The name of the database. This can be omitted (or

--- a/man/orderly_db_query.Rd
+++ b/man/orderly_db_query.Rd
@@ -4,12 +4,10 @@
 \alias{orderly_db_query}
 \title{Extract data from a database}
 \usage{
-orderly_db_query(query, as, database = NULL, instance = NULL)
+orderly_db_query(query, database = NULL, instance = NULL)
 }
 \arguments{
 \item{query}{Query to evaluate}
-
-\item{as}{Name of the object to create}
 
 \item{database}{The name of the database. This can be omitted (or
 \code{NULL}) where you only have a single database, but must be
@@ -20,7 +18,7 @@ specified if you have more than one database configured.}
 used instances or where you have only one configured.}
 }
 \value{
-Undefined
+The extracted data
 }
 \description{
 Extract data from a database

--- a/tests/testthat/examples/connection/orderly.R
+++ b/tests/testthat/examples/connection/orderly.R
@@ -1,6 +1,6 @@
 orderly2::orderly_artefact("Some data", "data.rds")
-orderly.db::orderly_db_connection("con")
-orderly.db::orderly_db_query(as = "dat", query = "SELECT * FROM mtcars")
+con <- orderly.db::orderly_db_connection()
+dat <- orderly.db::orderly_db_query("SELECT * FROM mtcars")
 
 dat_cmp <- DBI::dbReadTable(con, "mtcars")
 stopifnot(isTRUE(all.equal(dat, dat_cmp)))

--- a/tests/testthat/examples/connectiononly/orderly.R
+++ b/tests/testthat/examples/connectiononly/orderly.R
@@ -1,5 +1,5 @@
 orderly2::orderly_artefact("Some data", "data.rds")
-orderly.db::orderly_db_connection("con")
+con <- orderly.db::orderly_db_connection()
 
 dat <- DBI::dbReadTable(con, "mtcars")
 saveRDS(dat, "data.rds")

--- a/tests/testthat/examples/instance/orderly.R
+++ b/tests/testthat/examples/instance/orderly.R
@@ -1,11 +1,9 @@
-orderly.db::orderly_db_query(
+dat1 <- orderly.db::orderly_db_query(
   query = "SELECT * FROM mtcars",
-  as = "dat1",
   database = "db",
   instance = "main")
-orderly.db::orderly_db_query(
+dat2 <- orderly.db::orderly_db_query(
   query = "SELECT * FROM mtcars",
-  as = "dat2",
   database = "db",
   instance = "dev")
 

--- a/tests/testthat/examples/interpolate/orderly.R
+++ b/tests/testthat/examples/interpolate/orderly.R
@@ -1,7 +1,5 @@
 orderly2::orderly_parameters(mpg_min = NULL)
-orderly.db::orderly_db_query(
-  query = "SELECT * FROM mtcars WHERE mpg > ?mpg_min",
-  as = "dat")
+dat <- orderly.db::orderly_db_query("SELECT * FROM mtcars WHERE mpg > ?mpg_min")
 orderly2::orderly_artefact("Some data", "data.rds")
 
 saveRDS(dat, "data.rds")

--- a/tests/testthat/examples/minimal/orderly.R
+++ b/tests/testthat/examples/minimal/orderly.R
@@ -1,6 +1,4 @@
-orderly.db::orderly_db_query(
-  query = "SELECT * FROM mtcars",
-  as = "dat1")
+dat1 <- orderly.db::orderly_db_query("SELECT * FROM mtcars")
 orderly2::orderly_artefact("Some data", "data.rds")
 
 saveRDS(dat1, "data.rds")

--- a/tests/testthat/examples/query/orderly.R
+++ b/tests/testthat/examples/query/orderly.R
@@ -1,4 +1,4 @@
-orderly.db::orderly_db_query(query = "query.sql", as = "dat1")
+dat1 <- orderly.db::orderly_db_query(query = "query.sql")
 orderly2::orderly_artefact("Some data", "data.rds")
 
 saveRDS(dat1, "data.rds")

--- a/tests/testthat/examples/view/orderly.R
+++ b/tests/testthat/examples/view/orderly.R
@@ -2,8 +2,6 @@ orderly2::orderly_artefact("Some data", "data.rds")
 orderly.db::orderly_db_view(
   as = "thedata",
   query = "SELECT mpg, cyl FROM mtcars")
-orderly.db::orderly_db_query(
-  as = "dat",
-  query = "SELECT * FROM thedata")
+dat <- orderly.db::orderly_db_query("SELECT * FROM thedata")
 
 saveRDS(dat, "data.rds")

--- a/tests/testthat/test-plugin.R
+++ b/tests/testthat/test-plugin.R
@@ -238,3 +238,14 @@ test_that("can interpolate parameters into query", {
     meta_db$query[[1]]$query,
     sql_str_sub("SELECT * FROM mtcars WHERE mpg > 30"))
 })
+
+
+test_that("can run plugin interactively", {
+  root <- test_prepare_example("minimal",
+                               list(source = list(mtcars = mtcars_db)))
+  env <- new.env()
+  path_src <- file.path(root, "src", "minimal")
+  withr::with_dir(path_src, sys.source("orderly.R", env))
+  expect_equal(env$dat1, mtcars_db)
+  expect_true(file.exists(file.path(path_src, "data.rds")))
+})

--- a/tests/testthat/test-plugin.R
+++ b/tests/testthat/test-plugin.R
@@ -16,8 +16,7 @@ test_that("basic plugin use works", {
 
   expect_length(meta_db$query, 1)
   expect_setequal(names(meta_db$query[[1]]),
-                  c("as", "database", "query", "rows", "cols"))
-  expect_equal(meta_db$query[[1]]$as, "dat1")
+                  c("database", "query", "rows", "cols"))
   expect_equal(meta_db$query[[1]]$database, "source")
   expect_equal(meta_db$query[[1]]$rows, nrow(mtcars_db))
   expect_equal(meta_db$query[[1]]$cols, as.list(names(mtcars_db)))
@@ -47,8 +46,7 @@ test_that("allow connection", {
 
   expect_length(meta_db$query, 1)
   expect_setequal(names(meta_db$query[[1]]),
-                  c("as", "database", "query", "rows", "cols"))
-  expect_equal(meta_db$query[[1]]$as, "dat")
+                  c("database", "query", "rows", "cols"))
   expect_equal(meta_db$query[[1]]$database, "source")
   expect_equal(meta_db$query[[1]]$rows, nrow(mtcars_db))
   expect_equal(meta_db$query[[1]]$cols, as.list(names(mtcars_db)))
@@ -56,7 +54,7 @@ test_that("allow connection", {
 
   expect_length(meta_db$connection, 1)
   expect_mapequal(meta_db$connection[[1]],
-                  list(database = "source", as = "con"))
+                  list(database = "source"))
 })
 
 
@@ -79,7 +77,7 @@ test_that("allow connection without data", {
 
   expect_length(meta_db$connection, 1)
   expect_mapequal(meta_db$connection[[1]],
-                  list(database = "source", as = "con"))
+                  list(database = "source"))
 })
 
 


### PR DESCRIPTION
This PR simplifies the plugins so rather than writing data to the 'as' argument we simply return the data. Also includes a test of interactive running.