### PR TITLE
mrc-4700: add custom deserialiation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,6 +29,6 @@ Suggests:
     testthat (>= 3.0.0),
     withr
 Config/testthat/edition: 3
-Remotes: mrc-ide/orderly2
+Remotes: mrc-ide/orderly2@mrc-4437
 VignetteBuilder: knitr
 Language: en-GB

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,7 +30,7 @@ Suggests:
     withr
 Config/testthat/edition: 3
 Remotes:
-  mrc-ide/orderly2@mrc-4437,
+  mrc-ide/orderly2,
   ropensci/jsonvalidate
 VignetteBuilder: knitr
 Language: en-GB

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ Imports:
     DBI,
     fs,
     jsonlite,
-    orderly2 (>= 1.99.0)
+    orderly2 (>= 1.99.10)
 Suggests:
     RSQLite,
     knitr,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,6 +22,7 @@ Imports:
     orderly2 (>= 1.99.10)
 Suggests:
     RSQLite,
+    jsonvalidate (>= 1.4.0),
     knitr,
     mockery,
     rmarkdown,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,6 +29,8 @@ Suggests:
     testthat (>= 3.0.0),
     withr
 Config/testthat/edition: 3
-Remotes: mrc-ide/orderly2@mrc-4437
+Remotes:
+  mrc-ide/orderly2@mrc-4437,
+  ropensci/jsonvalidate
 VignetteBuilder: knitr
 Language: en-GB

--- a/R/plugin.R
+++ b/R/plugin.R
@@ -60,6 +60,28 @@ orderly_db_serialise <- function(data) {
 }
 
 
+orderly_db_deserialise <- function(data) {
+  if (!is.null(data$query)) {
+    data$query <- data_frame(
+      database = vcapply(data$query, "[[", "database"),
+      query = vcapply(data$query, "[[", "query"),
+      rows = viapply(data$query, "[[", "rows"),
+      cols = I(lapply(data$query, function(x) list_to_character(x$cols))))
+  }
+  if (!is.null(data$view)) {
+    data$view <- data_frame(
+      database = vcapply(data$view, "[[", "database"),
+      as = vcapply(data$view, "[[", "as"),
+      query = vcapply(data$view, "[[", "query"))
+  }
+  if (!is.null(data$connection)) {
+    data$connection <- data_frame(
+      database = vcapply(data$connection, "[[", "database"))
+  }
+  data
+}
+
+
 orderly_db_cleanup <- function() {
   ctx <- orderly2::orderly_plugin_context("orderly.db")
   local_connections_close(ctx$path)

--- a/R/util.R
+++ b/R/util.R
@@ -84,5 +84,25 @@ check_symbol_from_str <- function(str, name) {
 }
 
 
+vcapply <- function(...) {
+  vapply(..., FUN.VALUE = character(1))
+}
+
+
+viapply <- function(...) {
+  vapply(..., FUN.VALUE = integer(1))
+}
+
+
+list_to_character <- function(x) {
+  vcapply(x, identity, USE.NAMES = FALSE)
+}
+
+
+data_frame <- function(...) {
+  data.frame(..., stringsAsFactors = FALSE, check.names = FALSE)
+}
+
+
 ## this one is fairly unpleasant
 file_exists <- orderly2:::file_exists

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -4,6 +4,7 @@
     "orderly.db",
     config = orderly_db_config,
     serialise = orderly_db_serialise,
+    deserialise = orderly_db_deserialise,
     cleanup = orderly_db_cleanup,
     schema = "orderly.db.json")
   # nocov end

--- a/inst/orderly.db.json
+++ b/inst/orderly.db.json
@@ -5,7 +5,7 @@
 
     "type": "object",
     "properties": {
-        "data": {
+        "query": {
             "type": "array",
             "items": {
                 "type": "object",
@@ -22,11 +22,11 @@
                     "cols": {
                         "type": "array",
                         "items": {
-                            "type": "character"
+                            "type": "string"
                         }
                     }
                 },
-                "required": ["database", "query", "rows", "cols"]
+                "required": ["database", "query", "rows", "cols"],
                 "additionalProperties": false
             }
         },
@@ -45,7 +45,7 @@
                         "type": "string"
                     }
                 },
-                "required": ["database", "as", "query"]
+                "required": ["database", "as", "query"],
                 "additionalProperties": false
             }
         },
@@ -58,7 +58,7 @@
                         "type": "string"
                     }
                 },
-                "required": ["database"]
+                "required": ["database"],
                 "additionalProperties": false
             }
         }

--- a/tests/testthat/helper-orderly-db.R
+++ b/tests/testthat/helper-orderly-db.R
@@ -1,3 +1,7 @@
+options(outpack.schema_validate =
+          requireNamespace("jsonvalidate", quietly = TRUE) &&
+          packageVersion("jsonvalidate") >= "1.4.0")
+
 mtcars_db <- cbind(name = rownames(mtcars), mtcars)
 rownames(mtcars_db) <- NULL
 

--- a/tests/testthat/test-plugin.R
+++ b/tests/testthat/test-plugin.R
@@ -189,6 +189,14 @@ test_that("can construct a view, then read from it", {
     ## View not present here, it was only available to the client that
     ## created it.
     expect_equal(DBI::dbListTables(con), "mtcars"))
+
+  meta <- orderly2::orderly_metadata(id, root)
+  meta_db <- meta$custom$orderly.db
+  expect_setequal(names(meta_db), c("query", "view"))
+  expect_equal(meta_db$view,
+               data_frame(database = "source",
+                          as = "thedata",
+                          query = "SELECT mpg, cyl FROM mtcars"))
 })
 
 

--- a/tests/testthat/test-plugin.R
+++ b/tests/testthat/test-plugin.R
@@ -14,13 +14,13 @@ test_that("basic plugin use works", {
   meta_db <- meta$custom$orderly.db
   expect_equal(names(meta_db), "query")
 
-  expect_length(meta_db$query, 1)
-  expect_setequal(names(meta_db$query[[1]]),
-                  c("database", "query", "rows", "cols"))
-  expect_equal(meta_db$query[[1]]$database, "source")
-  expect_equal(meta_db$query[[1]]$rows, nrow(mtcars_db))
-  expect_equal(meta_db$query[[1]]$cols, as.list(names(mtcars_db)))
-  expect_equal(meta_db$query[[1]]$query, "SELECT * FROM mtcars")
+  expect_equal(nrow(meta_db$query), 1)
+  expect_equal(names(meta_db$query),
+               c("database", "query", "rows", "cols"))
+  expect_equal(meta_db$query$database, "source")
+  expect_equal(meta_db$query$rows, nrow(mtcars_db))
+  expect_equal(meta_db$query$cols, I(list(names(mtcars_db))))
+  expect_equal(meta_db$query$query, "SELECT * FROM mtcars")
 })
 
 
@@ -44,17 +44,16 @@ test_that("allow connection", {
   meta_db <- meta$custom$orderly.db
   expect_setequal(names(meta_db), c("query", "connection"))
 
-  expect_length(meta_db$query, 1)
-  expect_setequal(names(meta_db$query[[1]]),
-                  c("database", "query", "rows", "cols"))
-  expect_equal(meta_db$query[[1]]$database, "source")
-  expect_equal(meta_db$query[[1]]$rows, nrow(mtcars_db))
-  expect_equal(meta_db$query[[1]]$cols, as.list(names(mtcars_db)))
-  expect_equal(meta_db$query[[1]]$query, "SELECT * FROM mtcars")
+  expect_equal(nrow(meta_db$query), 1)
+  expect_equal(names(meta_db$query),
+               c("database", "query", "rows", "cols"))
+  expect_equal(meta_db$query$database, "source")
+  expect_equal(meta_db$query$rows, nrow(mtcars_db))
+  expect_equal(meta_db$query$cols, I(list(names(mtcars_db))))
+  expect_equal(meta_db$query$query, "SELECT * FROM mtcars")
 
-  expect_length(meta_db$connection, 1)
-  expect_mapequal(meta_db$connection[[1]],
-                  list(database = "source"))
+  expect_equal(nrow(meta_db$connection), 1)
+  expect_mapequal(meta_db$connection, data_frame(database = "source"))
 })
 
 
@@ -73,11 +72,10 @@ test_that("allow connection without data", {
 
   meta <- orderly2::orderly_metadata(id, root)
   meta_db <- meta$custom$orderly.db
-  expect_setequal(names(meta_db), "connection")
+  expect_equal(names(meta_db), "connection")
 
-  expect_length(meta_db$connection, 1)
-  expect_mapequal(meta_db$connection[[1]],
-                  list(database = "source"))
+  expect_equal(nrow(meta_db$connection), 1)
+  expect_equal(meta_db$connection, data_frame(database = "source"))
 })
 
 
@@ -202,7 +200,7 @@ test_that("can read a query from a file", {
 
   meta <- orderly2::orderly_metadata(id, root)
   meta_db <- meta$custom$orderly.db
-  expect_equal(meta_db$query[[1]]$query,
+  expect_equal(meta_db$query$query,
                readLines(file.path(root, "src", "query", "query.sql")))
 })
 
@@ -235,7 +233,7 @@ test_that("can interpolate parameters into query", {
   meta <- orderly2::orderly_metadata(id, root)
   meta_db <- meta$custom$orderly.db
   expect_equal(
-    meta_db$query[[1]]$query,
+    meta_db$query$query,
     sql_str_sub("SELECT * FROM mtcars WHERE mpg > 30"))
 })
 


### PR DESCRIPTION
~Uses https://github.com/mrc-ide/orderly2/pull/116, unpin after merge~

This PR adds custom deserialisation orderly.db metadata, using new support in orderly2; this will make interacting with packets that include db metadata easier. Includes fixes where we just were not validating the metadata!