### PR TITLE
Save additional metadata

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly.db
 Title: Database Support for 'orderly2'
-Version: 0.1.2
+Version: 0.1.3
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Imperial College of Science, Technology and Medicine",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,7 +12,7 @@ Description: Access databases from 'orderly2' while running reports.
 License: MIT + file LICENSE
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.1
 URL: https://github.com/vimc/orderly.db
 BugReports: https://github.com/vimc/orderly.db/issues
 Imports:

--- a/R/plugin.R
+++ b/R/plugin.R
@@ -64,19 +64,23 @@ orderly_db_deserialise <- function(data) {
   if (!is.null(data$query)) {
     data$query <- data_frame(
       database = vcapply(data$query, "[[", "database"),
+      instance = vcapply(data$query, get_or_na_string("instance")),
       query = vcapply(data$query, "[[", "query"),
       rows = viapply(data$query, "[[", "rows"),
-      cols = I(lapply(data$query, function(x) list_to_character(x$cols))))
+      cols = I(lapply(data$query, function(x) list_to_character(x$cols))),
+      name = vcapply(data$query, get_or_na_string("name")))
   }
   if (!is.null(data$view)) {
     data$view <- data_frame(
       database = vcapply(data$view, "[[", "database"),
+      instance = vcapply(data$view, get_or_na_string("instance")),
       as = vcapply(data$view, "[[", "as"),
       query = vcapply(data$view, "[[", "query"))
   }
   if (!is.null(data$connection)) {
     data$connection <- data_frame(
-      database = vcapply(data$connection, "[[", "database"))
+      database = vcapply(data$connection, "[[", "database"),
+      instance = vcapply(data$connection, get_or_na_string("instance")))
   }
   data
 }

--- a/R/util.R
+++ b/R/util.R
@@ -104,5 +104,12 @@ data_frame <- function(...) {
 }
 
 
+get_or_na_string <- function(name) {
+  function(x) {
+    x[[name]] %||% NA_character_
+  }
+}
+
+
 ## this one is fairly unpleasant
 file_exists <- orderly2:::file_exists

--- a/inst/orderly.db.json
+++ b/inst/orderly.db.json
@@ -13,6 +13,9 @@
                     "database": {
                         "type": "string"
                     },
+                    "instance": {
+                        "type": ["null", "string"]
+                    },
                     "query": {
                         "type": "string"
                     },
@@ -24,9 +27,12 @@
                         "items": {
                             "type": "string"
                         }
+                    },
+                    "name": {
+                        "type": ["null", "string"]
                     }
                 },
-                "required": ["database", "query", "rows", "cols"],
+                "required": ["database", "instance", "query", "rows", "cols", "name"],
                 "additionalProperties": false
             }
         },
@@ -38,6 +44,9 @@
                     "database": {
                         "type": "string"
                     },
+                    "instance": {
+                        "type": ["null", "string"]
+                    },
                     "as": {
                         "type": "string"
                     },
@@ -45,7 +54,7 @@
                         "type": "string"
                     }
                 },
-                "required": ["database", "as", "query"],
+                "required": ["database", "instance", "as", "query"],
                 "additionalProperties": false
             }
         },
@@ -56,9 +65,12 @@
                 "properties": {
                     "database": {
                         "type": "string"
+                    },
+                    "instance": {
+                        "type": ["null", "string"]
                     }
                 },
-                "required": ["database"],
+                "required": ["database", "instance"],
                 "additionalProperties": false
             }
         }

--- a/man/orderly_db_query.Rd
+++ b/man/orderly_db_query.Rd
@@ -4,7 +4,7 @@
 \alias{orderly_db_query}
 \title{Extract data from a database}
 \usage{
-orderly_db_query(query, database = NULL, instance = NULL)
+orderly_db_query(query, database = NULL, instance = NULL, name = NULL)
 }
 \arguments{
 \item{query}{Query to evaluate}
@@ -16,6 +16,9 @@ specified if you have more than one database configured.}
 \item{instance}{The instance of the database (within a given
 \code{database}). This can be omitted (or \code{NULL}) where you have not
 used instances or where you have only one configured.}
+
+\item{name}{An optional name that you can use to look up this
+query in your metadata.}
 }
 \value{
 The extracted data

--- a/tests/testthat/examples/named/orderly.R
+++ b/tests/testthat/examples/named/orderly.R
@@ -1,0 +1,4 @@
+dat1 <- orderly.db::orderly_db_query("SELECT * FROM mtcars", name = "input")
+orderly2::orderly_artefact("Some data", "data.rds")
+
+saveRDS(dat1, "data.rds")


### PR DESCRIPTION
Saves two bits of metadata

* instance, which we allowed the user to provide but never stored
* name, which we can use to allow a label to go with a query for later comparison

Updates for the schema, which is what I need for outpack.orderly in order to migrate the VIMC database metadata